### PR TITLE
[MAINTENANCE] Change installation instructions to utilize Git install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ Note that `dgtest` only works with codebases that use `pytest` as a testing fram
 
 To get started, install the CLI tool using:
 ```bash
-pip install git+https://github.com/superconductive/dgtest
+# Option 1: Local install
+git clone git@github.com:superconductive/dgtest.git
+pip install -e .
+
+# Option 2: Git install
+pip install -e git+https://github.com/superconductive/dgtest/#egg=dgtest
 ```
 
 `dgtest` uses the following dependencies under the hood:

--- a/README.md
+++ b/README.md
@@ -33,12 +33,7 @@ Note that `dgtest` only works with codebases that use `pytest` as a testing fram
 
 To get started, install the CLI tool using:
 ```bash
-# Get latest version from PyPi
-pip install dgtest
-
-# Get latest development version
-git clone git@github.com:superconductive/dgtest.git
-pip install -e .
+pip install git+https://github.com/superconductive/dgtest
 ```
 
 `dgtest` uses the following dependencies under the hood:


### PR DESCRIPTION
Instead of having to `git clone` the repo, we should just utilize `pip`'s Git install feature.

Additionally, we don't support `pip install dgtest` as the package is not on PyPI.