### PR TITLE
[MAINTENANCE] Remove upper bound on `pytest` in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Click>=7.1.2
 GitPython==3.1.18
-pytest>=5.3.5,<6.0.0
+pytest>=5.3.5


### PR DESCRIPTION
Originally added upper bound to have parity with OSS repo but no longer relevant.