### PR TITLE
add `pipx install` suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Note that `dgtest` only works with codebases that use `pytest` as a testing fram
 ### Installation
 
 To get started, install the CLI tool using:
-
 ```bash
 # Option 1 (recommend): pipx Git install
 pipx install git+https://github.com/superconductive/dgtest

--- a/README.md
+++ b/README.md
@@ -32,12 +32,16 @@ Note that `dgtest` only works with codebases that use `pytest` as a testing fram
 ### Installation
 
 To get started, install the CLI tool using:
+
 ```bash
-# Option 1: Local install
+# Option 1 (recommend): pipx Git install
+pipx install git+https://github.com/superconductive/dgtest
+
+# Option 2: Local install
 git clone git@github.com:superconductive/dgtest.git
 pip install -e .
 
-# Option 2: Git install
+# Option 3: Git install
 pip install -e git+https://github.com/superconductive/dgtest/#egg=dgtest
 ```
 


### PR DESCRIPTION
Installs `dgtest` in an isolated python virtual environment, while making it globally available from the command line.

https://pypa.github.io/pipx/

![image](https://user-images.githubusercontent.com/13108583/184148811-c8c76c02-2266-41a7-a63c-7fdabb160661.png)
